### PR TITLE
fix error when carrying objects with both hands

### DIFF
--- a/cram_pr2_synch_projection_pms/src/manipulation.lisp
+++ b/cram_pr2_synch_projection_pms/src/manipulation.lisp
@@ -119,9 +119,9 @@
                         (robot ?robot)
                         (end-effector-link ?robot :left ?left-end-effector)
                         (end-effector-link ?robot :right ?right-end-effector)
-                        (robot-arms-parking-joint-states
+                        (robot-arms-parking-joint-states ?robot
                          ?left-parking-joint-states :left)
-                        (robot-arms-parking-joint-states
+                        (robot-arms-parking-joint-states ?robot
                          ?right-parking-joint-states :right))))
     (let* ((left-gripper-transform
              (cl-transforms-stamped:lookup-transform

--- a/pr2_projection_process_modules/src/manipulation.lisp
+++ b/pr2_projection_process_modules/src/manipulation.lisp
@@ -119,9 +119,9 @@
                         (robot ?robot)
                         (end-effector-link ?robot :left ?left-end-effector)
                         (end-effector-link ?robot :right ?right-end-effector)
-                        (robot-arms-parking-joint-states
+                        (robot-arms-parking-joint-states ?robot
                          ?left-parking-joint-states :left)
-                        (robot-arms-parking-joint-states
+                        (robot-arms-parking-joint-states ?robot
                          ?right-parking-joint-states :right))))
     (let* ((left-gripper-transform
              (cl-transforms-stamped:lookup-transform


### PR DESCRIPTION
Hello CRAM team,

when a plate was grasped, the error "Couldn't resolve variable ?LEFT-END-EFFECTOR." occured.
This commit fixes the error.

Kind Regards,

Marc Niehaus