### PR TITLE
Made pr2_manipulation_process_module compile again (wrong `btr` symbo…

### DIFF
--- a/cram_pr2_designators/src/pick-and-place.lisp
+++ b/cram_pr2_designators/src/pick-and-place.lisp
@@ -173,7 +173,7 @@
           (t (cl-transforms:translation lift-transform)))))
 
 (defun object-type->tool-length (object-type)
-  (let ((bounding-box (btr:item-dimensions object-type)))
+  (let ((bounding-box (item-dimensions object-type)))
     (cram-robot-interfaces:calculate-bounding-box-tool-length
      bounding-box)))
 


### PR DESCRIPTION
…l removed)

The `btr` namespace symbol was used, which is not present anymore (and wasn't necessary here anyway as the namespace was resolved properly).