### PR TITLE
Nav timeout

### DIFF
--- a/pr2_navigation_process_module/src/designators.lisp
+++ b/pr2_navigation_process_module/src/designators.lisp
@@ -31,9 +31,11 @@
 
 (def-fact-group pr2-navigation-designators (action-desig)
   
-    (<- (action-desig ?designator ?goal-location)
-      (desig-prop ?designator (:type :navigation))
-      (desig-prop ?designator (:goal ?goal-location))))
+  (<- (action-desig ?designator ?goal-location ?timeout)
+    (desig-prop ?designator (:type :navigation))
+    (desig-prop ?designator (:goal ?goal-location))
+    (or (desig-prop ?designator (:timeout ?timeout))
+        (equal ?timeout 10.0))))
 
 (def-fact-group navigation-process-module (matching-process-module available-process-module)
 

--- a/pr2_navigation_process_module/src/designators.lisp
+++ b/pr2_navigation_process_module/src/designators.lisp
@@ -31,11 +31,9 @@
 
 (def-fact-group pr2-navigation-designators (action-desig)
   
-  (<- (action-desig ?designator ?goal-location ?timeout)
+  (<- (action-desig ?designator ?designator)
     (desig-prop ?designator (:type :navigation))
-    (desig-prop ?designator (:goal ?goal-location))
-    (or (desig-prop ?designator (:timeout ?timeout))
-        (equal ?timeout 10.0))))
+    (desig-prop ?designator (:goal ?goal-location))))
 
 (def-fact-group navigation-process-module (matching-process-module available-process-module)
 

--- a/pr2_navigation_process_module/src/process-module.lisp
+++ b/pr2_navigation_process_module/src/process-module.lisp
@@ -130,10 +130,10 @@
 
 (def-process-module pr2-navigation-process-module (desig)
   (when *navigation-enabled*
-      (unwind-protect
-           (progn
-             (roslisp:ros-info (pr2-nav process-module) "Using nav-pcontroller.")
-             (call-nav-action *navp-client* desig))
-        (roslisp:ros-info (pr2-nav process-module) "Navigation finished.")
-        (cram-occasions-events:on-event
-         (make-instance 'cram-plan-occasions-events:robot-state-changed)))))
+    (unwind-protect
+         (progn
+           (roslisp:ros-info (pr2-nav process-module) "Using nav-pcontroller.")
+           (call-nav-action *navp-client* desig))
+      (roslisp:ros-info (pr2-nav process-module) "Navigation finished.")
+      (cram-occasions-events:on-event
+       (make-instance 'cram-plan-occasions-events:robot-state-changed)))))


### PR DESCRIPTION
As discussed, the `:timeout` parameter is now an optional field when calling the `pr2_navigation_process_module`. It defaults to 10.0 seconds, which was the hard-coded value from before the change.

I had to slightly change how the goal location is resolved, because the `def-process-module` macro (and thus the implicit `pm-run` call inside the macro) doesn't allow more than one parameter (which needs to be a designator). Works for me, tested on the PR2 in Gazebo.