### PR TITLE
Tf frames fix

### DIFF
--- a/point_head_process_module/src/designator.lisp
+++ b/point_head_process_module/src/designator.lisp
@@ -42,7 +42,7 @@
                        (cl-transforms:make-3d-vector 3.0 0.0 1.5)
                        (cl-transforms:make-quaternion 0.0 0.0 0.0 1.0))
                       pose-stamped)
-            :target-frame "/base_link"
+            :target-frame "base_link"
             :timeout *tf-default-timeout*
             :use-current-ros-time t))
          (point-stamped-msg
@@ -51,7 +51,7 @@
      *action-client*
      max_velocity 10
      min_duration 0.3
-     pointing_frame "/high_def_frame"
+     pointing_frame "high_def_frame"
      (x pointing_axis) 1.0
      (y pointing_axis) 0.0
      (z pointing_axis) 0.0

--- a/pr2_manipulation_process_module/src/action-handlers.lisp
+++ b/pr2_manipulation_process_module/src/action-handlers.lisp
@@ -257,7 +257,7 @@
                   :effort (min-object-grasp-effort obj)))))
       (let ((params (mapcar #'grasp-parameters assignments-list)))
         (dolist (param-set params)
-          (let ((pub (roslisp:advertise "/dhdhdh" "geometry_msgs/PoseStamped")))
+          (let ((pub (roslisp:advertise "dhdhdh" "geometry_msgs/PoseStamped")))
             (roslisp:publish pub (to-msg (pregrasp-pose param-set))))
           (when (and obj-pose action-desig)
             (cram-language::on-grasp-decisions-complete
@@ -353,8 +353,8 @@
       (cpl:fail 'manipulation-pose-unreachable))))
 
 (defun pose-pointing-away-from-base (object-pose)
-  (let ((ref-frame "/base_link")
-        (fin-frame "/map"))
+  (let ((ref-frame "base_link")
+        (fin-frame "map"))
     (let* ((base-transform-map (cl-transforms-stamped:lookup-transform
                                 *transformer* fin-frame ref-frame
                                 :timeout *tf-default-timeout*))
@@ -449,9 +449,9 @@
                  (prolog:prolog
                   `(and (robot ?robot)
                         (planning-group ?robot ,side ?group)))))))
-        (publish-pose putdown-hand-pose "/putdownhandpose")
-        (publish-pose pre-putdown-pose "/preputdownpose")
-        (publish-pose unhand-pose "/unhandpose")
+        (publish-pose putdown-hand-pose "putdownhandpose")
+        (publish-pose pre-putdown-pose "preputdownpose")
+        (publish-pose unhand-pose "unhandpose")
         (unless (moveit:plan-link-movements
                  link-name planning-group
                  `(,pre-putdown-pose
@@ -495,7 +495,7 @@
                (prolog:prolog
                 `(and (robot ?robot)
                       (planning-group ?robot ,side ?group)))))))
-      (publish-pose pose "/handpose")
+      (publish-pose pose "handpose")
       (unless (moveit:plan-link-movements
                link-name planning-group `(,pose)
                :destination-validity-only t)
@@ -603,7 +603,7 @@
                             (declare (ignore f))
                             (ros-info (pr2 manip-pm) "Trying next putdown-pose.")
                             (return-from next-putdown-pose)))
-                       (publish-pose putdown-pose "/putdownpose")
+                       (publish-pose putdown-pose "putdownpose")
                        (perform-putdowns object-designator grasp-assignments putdown-pose)
                        (setf success t)
                        (success))))
@@ -640,7 +640,7 @@
                   (let ((pose (reference (desig-prop-value handle :at))))
                     (to-msg pose)))
                 absolute-handles)))
-    (let ((publisher (roslisp:advertise "/objecthandleposes" "geometry_msgs/PoseArray")))
+    (let ((publisher (roslisp:advertise "objecthandleposes" "geometry_msgs/PoseArray")))
       (roslisp:publish publisher
                        (roslisp:make-message
                         "geometry_msgs/PoseArray"

--- a/pr2_navigation_process_module/src/process-module.lisp
+++ b/pr2_navigation_process_module/src/process-module.lisp
@@ -130,10 +130,10 @@
 
 (def-process-module pr2-navigation-process-module (desig)
   (when *navigation-enabled*
-      (unwind-protect
-           (progn
-             (roslisp:ros-info (pr2-nav process-module) "Using nav-pcontroller.")
-             (call-nav-action *navp-client* desig))
-        (roslisp:ros-info (pr2-nav process-module) "Navigation finished.")
-        (cram-occasions-events:on-event
-         (make-instance 'cram-plan-occasions-events:robot-state-changed)))))
+    (unwind-protect
+         (progn
+           (roslisp:ros-info (pr2-nav process-module) "Using nav-pcontroller.")
+           (call-nav-action *navp-client* desig))
+      (roslisp:ros-info (pr2-nav process-module) "Navigation finished.")
+      (cram-occasions-events:on-event
+       (make-instance 'cram-plan-occasions-events:robot-state-changed)))))


### PR DESCRIPTION
The prepending "/" causes problems when looking up TF frames. This PR fixes old strings that still included the prepending "/". Additionally, the actionlib timeout values (still hard-coded) are now 10.0 instead of much lower values.