### PR TITLE
Timestamps for TF lookups

### DIFF
--- a/point_head_process_module/src/process-module.lisp
+++ b/point_head_process_module/src/process-module.lisp
@@ -72,7 +72,8 @@
               "Cannot resolve designator ~a. Ignoring." goal)))
       (cram-language::on-finish-move-head log-id success)
       (cram-occasions-events:on-event
-       (make-instance 'cram-plan-occasions-events:robot-state-changed)))))
+       (make-instance 'cram-plan-occasions-events:robot-state-changed
+                      :timestamp 0.0)))))
 
 (defun maybe-shutdown-thread ()
   (when (and *point-head-thread*

--- a/pr2_manipulation_process_module/src/action-handlers.lisp
+++ b/pr2_manipulation_process_module/src/action-handlers.lisp
@@ -237,7 +237,8 @@
                 *transformer*
                 :pose (relative-pose
                        (relative-pose pose grasp-offset)
-                       gripper-offset)
+                       gripper-offset
+                       :time 0.0)
                 :target-frame *robot-torso-frame*
                 :timeout *tf-default-timeout*))
              (grasp-parameters (assignment)

--- a/pr2_manipulation_process_module/src/motion-library.lisp
+++ b/pr2_manipulation_process_module/src/motion-library.lisp
@@ -572,12 +572,12 @@ positions, grasp-type, effort to use) are defined in the list
                                   :ignore-collisions t)))
                     target-arm-poses))))))
 
-(defun relative-pose (pose pose-offset)
+(defun relative-pose (pose pose-offset &key (time (ros-time)))
   "Applies the pose `pose-offset' as transformation into the pose
 `pose' and returns the result in the frame of `pose'."
   (pose->pose-stamped
    (frame-id pose)
-   (ros-time)
+   time
    (cl-transforms:transform-pose
     (cl-transforms:pose->transform pose)
     pose-offset)))

--- a/pr2_manipulation_process_module/src/motion-library.lisp
+++ b/pr2_manipulation_process_module/src/motion-library.lisp
@@ -184,7 +184,8 @@
                         (cram-language::on-finish-move-arm log-id t)
                         (let ((bs-update (cram-occasions-events:on-event
                                           (make-instance
-                                              'cram-plan-occasions-events:robot-state-changed))))
+                                           'cram-plan-occasions-events:robot-state-changed
+                                           :timestamp 0.0))))
                           (cond (plan-only result)
                                 (t bs-update)))))
                      (t (cram-language::on-finish-move-arm log-id nil)

--- a/pr2_manipulation_process_module/src/process-module.lisp
+++ b/pr2_manipulation_process_module/src/process-module.lisp
@@ -247,8 +247,10 @@
                    (position command) position
                    (max_effort command) max-effort)
           :result-timeout 1.0)
-      (cram-occasions-events:on-event (make-instance
-                                          'cram-plan-occasions-events:robot-state-changed)))))
+      (cram-occasions-events:on-event
+       (make-instance
+        'cram-plan-occasions-events:robot-state-changed
+        :timestamp 0.0)))))
 
 (defun open-gripper (side &key (max-effort 100.0) (position 0.085))
   (cram-language::on-open-gripper side max-effort position)
@@ -263,7 +265,8 @@
                        (max_effort command) max-effort)
               :result-timeout 1.0)
           (cram-occasions-events:on-event
-           (make-instance 'cram-plan-occasions-events:robot-state-changed)))
+           (make-instance 'cram-plan-occasions-events:robot-state-changed
+                          :timestamp 0.0)))
       (with-vars-bound (?carried-object ?gripper-link)
           (lazy-car (prolog `(and (object-in-hand ?carried-object ,side)
                                   (robot ?robot)

--- a/pr2_navigation_process_module/src/process-module.lisp
+++ b/pr2_navigation_process_module/src/process-module.lisp
@@ -136,4 +136,5 @@
            (call-nav-action *navp-client* desig))
       (roslisp:ros-info (pr2-nav process-module) "Navigation finished.")
       (cram-occasions-events:on-event
-       (make-instance 'cram-plan-occasions-events:robot-state-changed)))))
+       (make-instance 'cram-plan-occasions-events:robot-state-changed
+                      :timestamp 0.0)))))


### PR DESCRIPTION
Corrected several places in which timestamp parameters are given to TF's `lookup-transform`. This results in much smoother execution of the robot's activities as TF doesn't run into timeouts all the time.