### PR TITLE
Manipulation PR2

### DIFF
--- a/pr2_manipulation_process_module/src/action-handlers.lisp
+++ b/pr2_manipulation_process_module/src/action-handlers.lisp
@@ -596,10 +596,9 @@
                                            (when (desig-prop-value
                                                   object-designator
                                                   :dimensions)
-                                             (+ (/ (elt (desig-prop-value
-                                                         object-designator
-                                                         :dimensions)
-                                                        2)
+                                             (+ (/ (tf:z (desig-prop-value
+                                                          object-designator
+                                                          :dimensions))
                                                    2)
                                                 0.1))
                                            0.1)))

--- a/pr2_manipulation_process_module/src/action-handlers.lisp
+++ b/pr2_manipulation_process_module/src/action-handlers.lisp
@@ -109,14 +109,22 @@
                                    (:left "l_wrist_roll_link")
                                    (:right "r_wrist_roll_link")))
                                (arm-in-tll
-                                 (cl-transforms-stamped:transform-pose-stamped
-                                  *transformer*
-                                  :pose (make-pose-stamped
-                                         frame-id (ros-time)
-                                         (cl-transforms:make-identity-vector)
-                                         (cl-transforms:make-identity-rotation))
-                                  :target-frame *robot-torso-frame*
-                                  :timeout *tf-default-timeout*))
+                                 (let ((tll-pose
+                                         (make-pose-stamped
+                                          frame-id 0.0
+                                          (cl-transforms:make-identity-vector)
+                                          (cl-transforms:make-identity-rotation))))
+                                   (tf:wait-for-transform
+                                    *transformer*
+                                    :timeout *tf-default-timeout*
+                                    :time (tf:stamp tll-pose)
+                                    :source-frame (tf:frame-id tll-pose)
+                                    :target-frame *robot-torso-frame*)
+                                   (cl-transforms-stamped:transform-pose-stamped
+                                    *transformer*
+                                    :pose tll-pose
+                                    :target-frame *robot-torso-frame*
+                                    :timeout *tf-default-timeout*)))
                                (raised
                                  (copy-pose-stamped
                                   arm-in-tll
@@ -389,16 +397,23 @@
 (define-hook cram-language::on-finish-putdown (log-id success))
 
 (defun make-putdown-pose (putdown-location &key (z-offset 0.0))
-  (let* ((putdown-pose (or (desig-prop-value putdown-location 'pose)
-                           (pose-pointing-away-from-base
-                            (reference putdown-location))))
+  (let* ((putdown-pose (tf:copy-pose-stamped
+                        (or (desig-prop-value putdown-location 'pose)
+                            (pose-pointing-away-from-base
+                             (reference putdown-location)))
+                        :stamp 0.0))
          (pose-in-tll
-           (cl-transforms-stamped:transform-pose-stamped
-            *transformer*
-            :pose putdown-pose
-            :target-frame *robot-torso-frame*
-            :timeout *tf-default-timeout*
-            :use-current-ros-time t)))
+           (progn
+             (tf:wait-for-transform
+              *transformer*
+              :time (tf:stamp putdown-pose)
+              :source-frame (tf:frame-id putdown-pose)
+              :target-frame *robot-torso-frame*)
+             (cl-transforms-stamped:transform-pose-stamped
+              *transformer*
+              :pose putdown-pose
+              :target-frame *robot-torso-frame*
+              :timeout *tf-default-timeout*))))
     (copy-pose-stamped
      pose-in-tll :origin (cl-transforms:v+ (cl-transforms:origin pose-in-tll)
                                            (cl-transforms:make-3d-vector 0.0 0.0 z-offset)))))

--- a/pr2_manipulation_process_module/src/designator.lisp
+++ b/pr2_manipulation_process_module/src/designator.lisp
@@ -195,7 +195,8 @@
 
 (def-fact-group pr2-manipulation-designators (action-desig
                                               cram-language::grasp-effort
-                                              reorient-object)
+                                              reorient-object
+                                              close-radius)
   
   (<- (maximum-object-tilt nil ?max-tilt)
     (symbol-value pi ?max-tilt))
@@ -369,6 +370,9 @@
               :only-reachable t ?cost)
     (not (equal ?cost nil)))
 
+  (<- (close-radius ?object ?radius)
+    (fail))
+
   (<- (arm-handle-assignment ?object ?arm-handle-combo ?grasp-assignment)
     (desig-prop ?object (:type :semantic-handle))
     (member (?arm . ?handle) ?arm-handle-combo)
@@ -378,6 +382,10 @@
     (lisp-fun reference ?location ?pose)
     (open-gripper ?arm)
     (object-pose-reachable ?object ?pose ?arm)
+    (once (or (close-radius ?object ?radius)
+              ;; TODO(winkler): Additionally, check the object
+              ;; properties here.
+              (equal ?radius 0.0)))
     (lisp-fun make-grasp-assignment
               :side ?arm
               :grasp-type pull
@@ -386,6 +394,7 @@
               :pregrasp-offset ?pregrasp-offset
               :grasp-offset ?grasp-offset
               :gripper-offset ?gripper-offset
+              :close-radius ?radius
               ?grasp-assignment))
 
   (<- (arm-handle-assignment ?object ?arm-handle-combo ?grasp-assignment)

--- a/pr2_manipulation_process_module/src/designator.lisp
+++ b/pr2_manipulation_process_module/src/designator.lisp
@@ -480,7 +480,7 @@
     (desig-prop ?object (:at ?objloc))
     (current-designator ?objloc ?current-objloc)
     (desig-prop ?current-objloc (:in :gripper))
-    (setof ?grasp (and (desig-prop ?current-objloc (pose ?objpose))
+    (setof ?grasp (and (desig-prop ?current-objloc (:pose ?objpose))
                        (arm-for-pose ?objpose ?arm)
                        (member ?arm (:left :right))
                        (once

--- a/pr2_manipulation_process_module/src/designator.lisp
+++ b/pr2_manipulation_process_module/src/designator.lisp
@@ -238,7 +238,10 @@
   
   (<- (holding-arms ?desig ?arms)
     (current-designator ?desig ?current-desig)
-    (gripper-arms-in-belief ?current-desig ?arms))
+    (or (and (gripper-arms-in-belief ?current-desig ?arms)
+             (not (equal ?arms nil)))
+        (and (gripper-arms-in-desig ?current-desig ?arms)
+             (not (equal ?arms nil)))))
   
   (<- (handled-obj-desig? ?designator)
     (obj-desig? ?designator)
@@ -475,6 +478,15 @@
   
   (<- (grasp-type ?_ ?grasp-type)
     (equal ?grasp-type :push))
+  
+  (<- (gripper-arms-in-desig ?object ?arms)
+    (desig-prop ?object (:at ?objloc))
+    (current-designator ?objloc ?current-objloc)
+    (desig-prop ?current-objloc (:in :gripper))
+    (setof ?arm (and (desig-prop ?current-objloc (:pose ?objpose))
+                     (arm-for-pose ?objpose ?arm)
+                     (member ?arm (:left :right)))
+           ?arms))
   
   (<- (object-grasps-in-gripper ?object ?grasps)
     (desig-prop ?object (:at ?objloc))

--- a/pr2_manipulation_process_module/src/designator.lisp
+++ b/pr2_manipulation_process_module/src/designator.lisp
@@ -293,7 +293,7 @@
     (object->grasp-assignments ?current-obj ?grasp-assignments)
     (-> (desig-prop ?desig (:distance ?distance))
         (true)
-        (== ?distance 0.02)))
+        (== ?distance 0.1)))
 
   (<- (grasp-type ?obj ?grasp-type)
     (not (equal ?obj nil))

--- a/pr2_manipulation_process_module/src/designator.lisp
+++ b/pr2_manipulation_process_module/src/designator.lisp
@@ -409,6 +409,10 @@
     (lisp-fun reference ?location ?pose)
     (open-gripper ?arm)
     (object-pose-reachable ?object ?pose ?arm)
+    (once (or (close-radius ?object ?radius)
+              ;; TODO(winkler): Additionally, check the object
+              ;; properties here.
+              (equal ?radius 0.0)))
     (lisp-fun make-grasp-assignment
               :side ?arm
               :grasp-type ?grasp-type
@@ -417,6 +421,7 @@
               :pregrasp-offset ?pregrasp-offset
               :grasp-offset ?grasp-offset
               :gripper-offset ?gripper-offset
+              :close-radius ?radius
               ?grasp-assignment))
   
   (<- (grasped-object-handle (?object ?handle))

--- a/pr2_manipulation_process_module/src/grasping.lisp
+++ b/pr2_manipulation_process_module/src/grasping.lisp
@@ -198,7 +198,7 @@ applied."
 
 (defun make-grasp-assignment (&key side pose handle cost grasp-type
                                 pregrasp-offset grasp-offset
-                                gripper-offset)
+                                gripper-offset close-radius)
   (make-instance 'grasp-assignment
                  :side side
                  :pose pose
@@ -207,6 +207,7 @@ applied."
                  :ik-cost cost
                  :pregrasp-offset pregrasp-offset
                  :grasp-offset grasp-offset
+                 :close-radius close-radius
                  :gripper-offset gripper-offset))
 
 (defun cost-function-ik-pose (obj assignment pregrasp-offset grasp-offset

--- a/pr2_manipulation_process_module/src/kinematics.lisp
+++ b/pr2_manipulation_process_module/src/kinematics.lisp
@@ -78,12 +78,17 @@ is fundamentally different."
                        `(and (robot ?robot)
                              (planning-group ?robot ,side ?group))))))
          (pose-in-tll
-           (cl-transforms-stamped:transform-pose-stamped
-            *transformer*
-            :pose pose
-            :target-frame *robot-torso-frame*
-            :timeout *tf-default-timeout*
-            :use-current-ros-time t)))
+           (progn
+             (tf:wait-for-transform
+              *transformer*
+              :time 0.0
+              :source-frame (tf:frame-id pose)
+              :target-frame *robot-torso-frame*)
+             (cl-transforms-stamped:transform-pose-stamped
+              *transformer*
+              :pose (tf:copy-pose-stamped pose :stamp 0.0)
+              :target-frame *robot-torso-frame*
+              :timeout *tf-default-timeout*))))
     (let ((state-0 (moveit:plan-link-movement
                     wrist-frame arm-group pose-in-tll
                     :touch-links

--- a/pr2_manipulation_process_module/src/package.lisp
+++ b/pr2_manipulation_process_module/src/package.lisp
@@ -45,7 +45,8 @@
   (:shadowing-import-from #:cram-designators object object-designator)
   (:export pr2-manipulation-process-module
            wait-for-controller
-           reorient-object)
+           reorient-object
+           close-radius)
   (:desig-properties #:trajectory #:type #:to #:open #:obj #:side #:sides #:close
                      #:grasp #:put-down #:pose #:parked #:lift
                      #:carry #:at #:orientation #:in #:gripper #:both-grippers


### PR DESCRIPTION
Made sure that poses are transformable by always using the latest available. Also, several adaptations for convenience Prolog predicates, fixes for missing keywords, and minor manipulation details like the default lifting distance.