### PR TITLE
Some retouches to the capmap code

### DIFF
--- a/pr2_reachability_costmap/src/reachability-map.lisp
+++ b/pr2_reachability_costmap/src/reachability-map.lisp
@@ -249,9 +249,9 @@
                                                  :ik-link-name link-name
                                                  :group-name group-name
                                                  :ik-base-frame-name ik-base-name)
-                                               (format t ".")
+                                               ;;(format t ".")
                                                (setf (aref map z-index y-index x-index angle-index) 1))
-                                              (t (format t "x")
+                                              (t ;;(format t "x")
                                                  (setf (aref map z-index y-index x-index angle-index) 0))))
                             finally (format t "~%")))
           finally (return map))))

--- a/pr2_reachability_costmap/src/reachability-map.lisp
+++ b/pr2_reachability_costmap/src/reachability-map.lisp
@@ -35,7 +35,7 @@
   ((side :reader side :initarg :side :type (or :left :right))
    (minimum :reader minimum :initarg :minimum :type cl-transforms:3d-vector)
    (maximum :reader maximum :initarg :maximum :type cl-transforms:3d-vector)
-   (resolution :reader resolution :initarg :resolution ::type cl-transforms:3d-vector)
+   (resolution :reader resolution :initarg :resolution :type cl-transforms:3d-vector)
    (orientations :reader orientations :initarg :orientations :type list)
    (reachability-map :reader reachability-map)
    (inverse-reachability-map :reader inverse-reachability-map)))

--- a/pr2_reachability_costmap/src/reachability-map.lisp
+++ b/pr2_reachability_costmap/src/reachability-map.lisp
@@ -208,53 +208,55 @@
                                                        (cl-transforms:make-3d-vector x y z)
                                                        angle)
                                                 :service-namespace namespace)
-                                               (format t ".")
+                                               ;(format t ".")
                                                (setf (aref map z-index y-index x-index angle-index) 1))
-                                              (t (format t "x")
+                                              (t ;(format t "x")
                                                  (setf (aref map z-index y-index x-index angle-index) 0))))
                             finally (format t "~%")))
           finally (return map))))
 
-(defun generate-moveit-reachability-map (map link-name group-name ik-base-name)
-  (with-slots (minimum maximum resolution orientations) map
-    (loop with map = (make-array
-                      (list
-                       (1+ (round (- (cl-transforms:z maximum)
-                                     (cl-transforms:z minimum))
-                                  (cl-transforms:z resolution)))
-                       (1+ (round (- (cl-transforms:y maximum)
-                                     (cl-transforms:y minimum))
-                                  (cl-transforms:y resolution)))
-                       (1+ (round (- (cl-transforms:x maximum)
-                                     (cl-transforms:x minimum))
-                                  (cl-transforms:x resolution)))
-                       (length orientations))
-                      :element-type 'bit)
-          for z from (cl-transforms:z minimum)
-            by (cl-transforms:z resolution)
-          for z-index from 0 below (array-dimension map 0)
-          do (loop for y from (cl-transforms:y minimum)
-                     by (cl-transforms:y resolution)
-                   for y-index from 0 below (array-dimension map 1)
-                   do (format t "y: ~a z: ~a~%" y z)
-                      (loop for x from (cl-transforms:x minimum)
-                              by (cl-transforms:x resolution)
-                            for x-index from 0 below (array-dimension map 2)
-                            do (loop for angle in orientations
-                                     for angle-index from 0
-                                     do (cond ((moveit-find-ik-solution
-                                                 :pose (cl-transforms:make-pose
-                                                         (cl-transforms:make-3d-vector x y z)
-                                                         angle)
-                                                 :ik-link-name link-name
-                                                 :group-name group-name
-                                                 :ik-base-frame-name ik-base-name)
-                                               ;;(format t ".")
-                                               (setf (aref map z-index y-index x-index angle-index) 1))
-                                              (t ;;(format t "x")
-                                                 (setf (aref map z-index y-index x-index angle-index) 0))))
-                            finally (format t "~%")))
-          finally (return map))))
+(defun generate-moveit-reachability-map (reachability-map link-name group-name ik-base-name)
+  (with-slots (minimum maximum resolution orientations) reachability-map
+    (setf (reachability-map reachability-map)
+      (loop with map = (make-array
+                        (list
+                         (1+ (round (- (cl-transforms:z maximum)
+                                       (cl-transforms:z minimum))
+                                    (cl-transforms:z resolution)))
+                         (1+ (round (- (cl-transforms:y maximum)
+                                       (cl-transforms:y minimum))
+                                    (cl-transforms:y resolution)))
+                         (1+ (round (- (cl-transforms:x maximum)
+                                       (cl-transforms:x minimum))
+                                    (cl-transforms:x resolution)))
+                         (length orientations))
+                        :element-type 'bit)
+            for z from (cl-transforms:z minimum)
+              by (cl-transforms:z resolution)
+            for z-index from 0 below (array-dimension map 0)
+            do (loop for y from (cl-transforms:y minimum)
+                       by (cl-transforms:y resolution)
+                     for y-index from 0 below (array-dimension map 1)
+                     do (format t "y: ~a z: ~a~%" y z)
+                        (loop for x from (cl-transforms:x minimum)
+                                by (cl-transforms:x resolution)
+                              for x-index from 0 below (array-dimension map 2)
+                              do (loop for angle in orientations
+                                       for angle-index from 0
+                                       do (cond ((moveit-find-ik-solution
+                                                   :pose (cl-transforms:make-pose
+                                                           (cl-transforms:make-3d-vector x y z)
+                                                           angle)
+                                                   :ik-link-name link-name
+                                                   :group-name group-name
+                                                   :ik-base-frame-name ik-base-name)
+                                                 ;;(format t ".")
+                                                 (setf (aref map z-index y-index x-index angle-index) 1))
+                                                (t ;;(format t "x")
+                                                   (setf (aref map z-index y-index x-index angle-index) 0))))
+                              finally (format t "~%")))
+            finally (return map)))
+    reachability-map))
 
 (defun generate-inverse-reachability-map (reachability-map)
   "Returns a new four-dimensional array that represents an inverse
@@ -303,8 +305,11 @@ result is: (z y x orientation)"
                                                      orientation-index)
                                                (cond ((origin-reachable-p
                                                        (cl-transforms:make-3d-vector x y z) orientation)
-                                                      (format t ".") 1)
-                                                     (t (format t "x") 0)))))
+                                                       ;;(format t ".")
+                                                       1)
+                                                     (t 
+                                                       ;;(format t "x")
+                                                       0)))))
                         (format t "~%")))
       inverse-reachability-map-matrix)))
 

--- a/pr2_reachability_costmap/src/reachability-map.lisp
+++ b/pr2_reachability_costmap/src/reachability-map.lisp
@@ -33,11 +33,15 @@
 
 (defclass reachability-map ()
   ((side :reader side :initarg :side :type (or :left :right))
+   (moveit :reader moveit :initarg :moveit :initform nil)
+   (ik-link-name :reader ik-link-name :initarg :ik-link-name :initform "" :type string)
+   (group-name :reader group-name :initarg :group-name :initform "" :type string)
+   (ik-base-name :reader ik-base-name :initarg :ik-base-name :initform "" :type string)
    (minimum :reader minimum :initarg :minimum :type cl-transforms:3d-vector)
    (maximum :reader maximum :initarg :maximum :type cl-transforms:3d-vector)
    (resolution :reader resolution :initarg :resolution :type cl-transforms:3d-vector)
    (orientations :reader orientations :initarg :orientations :type list)
-   (reachability-map :reader reachability-map)
+   (reachability-map :accessor reachability-map)
    (inverse-reachability-map :reader inverse-reachability-map)))
 
 (defgeneric origin (reachability-map)
@@ -76,10 +80,12 @@
 
 (defmethod reachability-map :before ((map reachability-map))
   (unless (slot-boundp map 'reachability-map)
-    (with-slots (side) map
+    (with-slots (side moveit ik-link-name ik-base-name group-name) map
       (setf (slot-value map 'reachability-map)
-            (generate-reachability-map
-             map :namespace (cdr (assoc side *arm-namespaces*)))))))
+            (if moveit
+              (generate-moveit-reachability-map map ik-link-name group-name ik-base-name)
+              (generate-reachability-map
+                map :namespace (cdr (assoc side *arm-namespaces*))))))))
 
 (defmethod inverse-reachability-map :before ((map reachability-map))
   (unless (slot-boundp map 'inverse-reachability-map)
@@ -202,6 +208,47 @@
                                                        (cl-transforms:make-3d-vector x y z)
                                                        angle)
                                                 :service-namespace namespace)
+                                               (format t ".")
+                                               (setf (aref map z-index y-index x-index angle-index) 1))
+                                              (t (format t "x")
+                                                 (setf (aref map z-index y-index x-index angle-index) 0))))
+                            finally (format t "~%")))
+          finally (return map))))
+
+(defun generate-moveit-reachability-map (map link-name group-name ik-base-name)
+  (with-slots (minimum maximum resolution orientations) map
+    (loop with map = (make-array
+                      (list
+                       (1+ (round (- (cl-transforms:z maximum)
+                                     (cl-transforms:z minimum))
+                                  (cl-transforms:z resolution)))
+                       (1+ (round (- (cl-transforms:y maximum)
+                                     (cl-transforms:y minimum))
+                                  (cl-transforms:y resolution)))
+                       (1+ (round (- (cl-transforms:x maximum)
+                                     (cl-transforms:x minimum))
+                                  (cl-transforms:x resolution)))
+                       (length orientations))
+                      :element-type 'bit)
+          for z from (cl-transforms:z minimum)
+            by (cl-transforms:z resolution)
+          for z-index from 0 below (array-dimension map 0)
+          do (loop for y from (cl-transforms:y minimum)
+                     by (cl-transforms:y resolution)
+                   for y-index from 0 below (array-dimension map 1)
+                   do (format t "y: ~a z: ~a~%" y z)
+                      (loop for x from (cl-transforms:x minimum)
+                              by (cl-transforms:x resolution)
+                            for x-index from 0 below (array-dimension map 2)
+                            do (loop for angle in orientations
+                                     for angle-index from 0
+                                     do (cond ((moveit-find-ik-solution
+                                                 :pose (cl-transforms:make-pose
+                                                         (cl-transforms:make-3d-vector x y z)
+                                                         angle)
+                                                 :ik-link-name link-name
+                                                 :group-name group-name
+                                                 :ik-base-frame-name ik-base-name)
                                                (format t ".")
                                                (setf (aref map z-index y-index x-index angle-index) 1))
                                               (t (format t "x")

--- a/pr2_reachability_costmap/src/ros.lisp
+++ b/pr2_reachability_costmap/src/ros.lisp
@@ -78,7 +78,7 @@
            (type string group-name)
            (type string ik-base-frame-name)
            (type cl-transforms:pose pose))
-  (format t "IK for ~a in group ~a with base ~a~%" ik-link-name group-name ik-base-frame-name)
+  ;;(format t "IK for ~a in group ~a with base ~a~%" ik-link-name group-name ik-base-frame-name)
   (let* ((dummy nil))
     (declare (ignore dummy))
     (roslisp:with-fields ((error-code (val error_code))
@@ -91,7 +91,7 @@
                         :avoid_collisions T
                         :pose_stamped (to-msg
                                         (pose->pose-stamped ik-base-frame-name 0.0 pose))
-                        :timeout 0.02))
+                        :timeout 0.01))
       (cond ((eql error-code
                   (roslisp-msg-protocol:symbol-code
                    'moveit_msgs-msg:moveiterrorcodes

--- a/pr2_reachability_costmap/src/ros.lisp
+++ b/pr2_reachability_costmap/src/ros.lisp
@@ -91,7 +91,7 @@
                         :avoid_collisions T
                         :pose_stamped (to-msg
                                         (pose->pose-stamped ik-base-frame-name 0.0 pose))
-                        :timeout 0.01))
+                        :timeout 0.005))
       (cond ((eql error-code
                   (roslisp-msg-protocol:symbol-code
                    'moveit_msgs-msg:moveiterrorcodes


### PR DESCRIPTION
At some point, the reachability costmap code should be out of the cram_pr2 package because it is more general than just the PR2. Will refactor soon.

Until then, pushing some changes: reduced timeouts, use the moveit interface more directly, do not use persistent services.