### PR TITLE
Implemented aux function to complete yaml-templates with constraints …

### DIFF
--- a/cram_pr2_plans/src/pour.lisp
+++ b/cram_pr2_plans/src/pour.lisp
@@ -216,13 +216,25 @@
                                 (destination ?perceived-cup-desig)))
     (move-pr2-arms-out-of-sight :arm ?arm)))
 
-(defun georgs-function (yaml-string list-of-constraints)
-  (declare (type string yaml-string)
-           (type list list-of-constraints))
+(defun georgs-function (yaml-format constraints)
+  (declare (type string yaml-format)
+           (type list constraints))
   "The list of constraints looks like the following:
 '((constraint-1 23 34)
   (constraint-2 45 47))"
-  yaml-string)
+  (let* ((constraint-indeces
+           '(("source_top_behind_goal_target_top" 0)
+             ("source_top_left_goal_target_top" 1)
+             ("source_top_above_goal_target_top"2)
+             ("source_behind_itself" 6)
+             ("source_left_itself" 7)
+             ("source_above_itself" 8)))
+         (replacements (make-array (* 2 (length constraint-indeces)))))
+    (dolist (constraint constraints)
+      (let ((index (second (find (car constraint) constraint-indeces :key #'car :test #'string=))))
+        (setf (elt replacements index) (second constraint))
+        (setf (elt replacements (+ index 3)) (third constraint))))
+    (apply #'format nil yaml-format (coerce replacements 'list))))
 
 (defun put-together-yaml (phase constraints)
   (georgs-function


### PR DESCRIPTION
…for pouring with giskard.

@gaya- The corresponding template files can be found here:
https://github.com/SemRoCo/giskard_examples/tree/master/controller_specs/pr2_pouring_example/templates

I used the following call for testing and developing:

```lisp
ROSLISP> (georgs-function (read-yaml-file :approach) *dummy-constraints*)
```

Together with this additional functions and parameters, and ```roslisp``` loaded:

```lisp
(defparameter *controller-filenames*
  '((:approach "move_above_controller" "move_above_thresholds")
    (:tilt-down "tilt_down_controller" "tilt_down_thresholds")
    (:tilt-back "tilt_back_controller" "tilt_back_thresholds")))

(defparameter *dummy-constraints*
  '(("source_top_behind_goal_target_top" 1 2)
    ("source_top_left_goal_target_top" 3 4)
    ("source_top_above_goal_target_top" 5 6)
    ("source_behind_itself" 7 8)
    ("source_left_itself" 9 10)
    ("source_above_itself" 11 12)))

(defparameter *dummy-yaml-string*
  "[~a, ~a, ~a], [~a, ~a, ~a]~%[~a, ~a, ~a], [~a, ~a, ~a]")

(defun file-string (path)
  "snippet from Rosetta-Code"
  (with-open-file (stream path)
    (let ((data (make-string (file-length stream))))
      (read-sequence data stream)
      data)))

(defun read-yaml-file (controller)
  (declare (type keyword controller))
  (let* ((uri (format nil
                      "package://giskard_examples/controller_specs/pr2_pouring_example/templates/~a.yaml.lisp"
                      (second (assoc controller *controller-filenames*))))
         (yaml-in-a-string (file-string (namestring (parse-uri uri)))))
    (format t "EXECUTING URI: ~a~%~%" uri)
    yaml-in-a-string))

(defun parse-uri (uri)
  (let ((uri-package-prefix "package://"))
    (cond ((equal (subseq uri 0 (length uri-package-prefix))
                  uri-package-prefix)
           (let* ((uri-sans-prefix (subseq uri (length uri-package-prefix)))
                  (package-name (subseq uri-sans-prefix 0
                                        (position #\/ uri-sans-prefix)))
                  (package-path (car (ros-load:rospack "find" package-name))))
             (when package-path
               (pathname
                (concatenate
                 'string
                 package-path "/"
                 (subseq uri-sans-prefix (position #\/ uri-sans-prefix)))))))
          (t (pathname uri)))))

(defun georgs-function (yaml-format constraints)
  (declare (type string yaml-format)
           (type list constraints))
  "The list of constraints looks like the following:
'((constraint-1 23 34)
  (constraint-2 45 47))"
  (let* ((constraint-indeces
           '(("source_top_behind_goal_target_top" 0)
             ("source_top_left_goal_target_top" 1)
             ("source_top_above_goal_target_top"2)
             ("source_behind_itself" 6)
             ("source_left_itself" 7)
             ("source_above_itself" 8)))
         (replacements (make-array (* 2 (length constraint-indeces)))))
    (dolist (constraint constraints)
      (let ((index (second (find (car constraint) constraint-indeces :key #'car :test #'string=))))
        (setf (elt replacements index) (second constraint))
        (setf (elt replacements (+ index 3)) (third constraint))))
    (apply #'format nil yaml-format (coerce replacements 'list))))
```